### PR TITLE
Update gemspec with current conventions

### DIFF
--- a/stitches.gemspec
+++ b/stitches.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.executables   = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_dependency("rails")
-  s.add_dependency("pg")
+  s.add_runtime_dependency("rails")
+  s.add_runtime_dependency("pg")
   s.add_development_dependency("rake")
-  s.add_dependency("rspec-rails", "~> 3")
-  s.add_dependency("apitome")
+  s.add_runtime_dependency("rspec-rails", "~> 3")
+  s.add_runtime_dependency("apitome")
 end


### PR DESCRIPTION
1. Change executable dir to `exe` see http://bundler.io/blog/2015/03/20/moving-bins-to-exe.html
2. [`s/add_dependency/add_runtime_dependency`](http://guides.rubygems.org/patterns/#declaring-dependencies)

I think it would also be a good idea to only shell out to git less.  Right now, anyone bundling this gem from source is going to have to shell out three times.

```ruby
s.files         = `git ls-files`.split("\n")
s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
s.executables   = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
```

Also, some changes that would require discussion and don't fit neatly into this pr:

1. Since RubyGems [no longer support running tests based on `test_files`](https://github.com/rubygems/rubygems-test/issues/36) and this repo has no executables, you could just remove those two lines.

2. It's probably a good idea to specify some version constraint on all the runtime_dependencies. e.g. rails `[">= 3.0", "< 5.0"]` if you want to be super broad about it.

3. `"rspec-rails", "~> 3"` I'm guessing you probably mean `~> 3.0`. `~>3` will include 4.0, which I'm guessing isn't intended. ref: http://www.benjaminfleischer.com/2013/08/21/psa-gem-versions/