### PR TITLE
Remove keyword arguments to Support Ruby 1.9.3

### DIFF
--- a/lib/stitches/error.rb
+++ b/lib/stitches/error.rb
@@ -1,7 +1,15 @@
 module Stitches
   class Error
+    class MissingParameter < StandardError; end
+
     attr_reader :code, :message
     def initialize(options = {})
+      [:code, :message].each do |key|
+        unless options.has_key?(key)
+          raise MissingParameter, "#{ self.class.name } must be initialized with :#{ key }"
+        end
+      end
+
       @code    = options[:code]
       @message = options[:message]
     end

--- a/lib/stitches/error.rb
+++ b/lib/stitches/error.rb
@@ -1,9 +1,9 @@
 module Stitches
   class Error
     attr_reader :code, :message
-    def initialize(code:, message:)
-      @code    = code
-      @message = message
+    def initialize(options = {})
+      @code    = options[:code]
+      @message = options[:message]
     end
   end
 end

--- a/lib/stitches/spec/api_clients.rb
+++ b/lib/stitches/spec/api_clients.rb
@@ -1,5 +1,5 @@
 module ApiClients
-  def api_client(name: "test")
-    ::ApiClient.where(name: name).first or ::ApiClient.create!(name: name).reload
+  def api_client(options = { name: "test" })
+    ::ApiClient.where(name: options[:name]).first or ::ApiClient.create!(name: options[:name]).reload
   end
 end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -4,14 +4,10 @@ module Stitches
   describe Error do
     describe '#initialize' do
       context 'required params are set' do
-        subject { described_class.new(code: anything, message: anything) }
-
-        it 'sets the code ivar' do
-          expect(subject.instance_variable_get(:@code)).to_not be_nil
-        end
-
-        it 'sets the message ivar' do
-          expect(subject.instance_variable_get(:@message)).to_not be_nil
+        it 'does not raise error' do
+          expect do
+            described_class.new(code: anything, message: anything)
+          end.to_not raise_error
         end
       end
 

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+module Stitches
+  describe Error do
+    describe '#initialize' do
+      context 'required params are set' do
+        subject { described_class.new(code: anything, message: anything) }
+
+        it 'sets the code ivar' do
+          expect(subject.instance_variable_get(:@code)).to_not be_nil
+        end
+
+        it 'sets the message ivar' do
+          expect(subject.instance_variable_get(:@message)).to_not be_nil
+        end
+      end
+
+      context 'code is missing' do
+        it 'raises a descriptive error' do
+          expect do
+            described_class.new(message: 'foo')
+          end.to raise_error(
+                    described_class::MissingParameter,
+                    'Stitches::Error must be initialized with :code')
+        end
+      end
+
+      context 'message is missing' do
+        it 'raises a descriptive error' do
+          expect do
+            described_class.new(code: 123)
+          end.to raise_error(
+                    described_class::MissingParameter,
+                    'Stitches::Error must be initialized with :message')
+        end
+      end
+
+      context 'both are missing' do
+        it 'raises an error about code' do
+          expect do
+            described_class.new(message: 'foo')
+          end.to raise_error(
+                  described_class::MissingParameter,
+                  'Stitches::Error must be initialized with :code')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
@webdestroya 

The `.travis.yml` file indicates that 1.9.3 is a version that should be
  tested. However, keyword arguments were not introduced until Ruby 2.

This keeps the perceived contract of affected `api_client` and `error`
  classes by replacing keyword arguments with a hash.
  **To consumers of these classes, nothing has changed.**

If this patch is unwanted, I would suggest removing 1.9.3 from the
  `.travis.yml` list of Rubies to build.