### PR TITLE
Use code variable in creation of Error class

### DIFF
--- a/lib/stitches/errors.rb
+++ b/lib/stitches/errors.rb
@@ -75,7 +75,7 @@ module Stitches
                   else
                     object.errors.full_messages_for(field).sort.join(', ')
                   end
-        Stitches::Error.new(code: "#{field}_invalid".parameterize, message: message)
+        Stitches::Error.new(code: code, message: message)
       }
       self.new(errors)
     end


### PR DESCRIPTION
Instead of `"#{field}_invalid".parameterize` in the `Error.new` class, use `code` variable

``` ruby
    def self.from_active_record_object(object)
      errors = object.errors.to_hash.map { |field,errors|
        code = "#{field}_invalid".parameterize
        message = if object.send(field).respond_to?(:errors)
                    object.send(field).errors.full_messages.sort.join(', ')
                  else
                    object.errors.full_messages_for(field).sort.join(', ')
                  end
        Stitches::Error.new(code: "#{field}_invalid".parameterize, message: message)
      }
      self.new(errors)
    end
```