### PR TITLE
Fixes some issues with the generator

### DIFF
--- a/lib/stitches/api_generator.rb
+++ b/lib/stitches/api_generator.rb
@@ -53,7 +53,8 @@ mount api_docs, at: "docs"
 
       inject_into_file "Gemfile", after: /^group :test, :development do.*$/ do<<-GEM
 
-gem "rspec_api_documentation"
+  gem "rspec_api_documentation"
+  gem "capybara"
       GEM
       end
       run 'bundle install'
@@ -62,16 +63,17 @@ gem "rspec_api_documentation"
       sleep 1 # allow clock to tick so we get different numbers
       migration_template "db/migrate/create_api_clients.rb", "db/migrate/create_api_clients.rb"
 
-      inject_into_file 'spec/spec_helper.rb', %q{
+      inject_into_file 'spec/rails_helper.rb', %q{
 config.include RSpec::Rails::RequestExampleGroup, type: :feature
 }, before: /^end/
 
-      inject_into_file 'spec/spec_helper.rb', before: /^RSpec.configure/ do<<-REQUIRE
+      inject_into_file 'spec/rails_helper.rb', before: /^RSpec.configure/ do<<-REQUIRE
 require 'stitches/spec'
       REQUIRE
       end
 
-      append_to_file 'spec/spec_helper.rb' do<<-RSPEC_API
+      append_to_file 'spec/rails_helper.rb' do<<-RSPEC_API
+require 'rspec_api_documentation'
 RspecApiDocumentation.configure do |config|
 config.format = :json
 config.request_headers_to_include = %w(

--- a/lib/stitches/generator_files/spec/acceptance/ping_v1_spec.rb
+++ b/lib/stitches/generator_files/spec/acceptance/ping_v1_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 
 resource "Ping (V1)" do

--- a/lib/stitches/generator_files/spec/features/api_spec.rb
+++ b/lib/stitches/generator_files/spec/features/api_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper.rb'
+require 'rails_helper.rb'
 
 feature "general API stuff" do
   scenario "good request" do


### PR DESCRIPTION
- putting stuff in spec_helper that should be in rails_helper
- not requiring some gems when needed
- referencing spec_helper instead of rails_helper
- not including capybara (not sure why this isn't brought in by rspec_api_documentation)

We need a better test of the generator.  It's tricky, but we basically need a test that:

1. `rails new blah`
1. Add `stitches` to the `Gemfile`
1. Run rspec and stitches generators
1. configure a database
1. Run the specs of the generated rails app

Tests like this are hard to keep from being brittle.  Any thoughts on if I should try to do that before merging this?


Fixes #17 
