### PR TITLE
Add simple options for disabling API authorization in development

### DIFF
--- a/lib/stitches/api_key.rb
+++ b/lib/stitches/api_key.rb
@@ -28,6 +28,8 @@ module Stitches
   protected
 
     def do_call(env)
+      return if @configuration.disable_authorization || ENV['DISABLE_API_AUTHORIZATION'] == 'true'
+
       authorization = env["HTTP_AUTHORIZATION"]
       if authorization
         if authorization =~ /#{@configuration.custom_http_auth_scheme}\s+key=(.*)\s*$/

--- a/lib/stitches/api_key.rb
+++ b/lib/stitches/api_key.rb
@@ -28,7 +28,7 @@ module Stitches
   protected
 
     def do_call(env)
-      return if @configuration.disable_authorization || ENV['DISABLE_API_AUTHORIZATION'] == 'true'
+      return if @configuration.disable_api_auth
 
       authorization = env["HTTP_AUTHORIZATION"]
       if authorization


### PR DESCRIPTION
What do people think about this? I think the overhead of maintaining API keys in dev in the local databases is worth eliminating. There are lots of ways to do this, but this one seem easy. 