### PR TITLE
Fix deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ Stitches.configure do |config|
 end
 
 # config/application.rb
-config.app_middleware.use "Stitches::ApiKey", except: %r{/super-secret}
-config.app_middleware.use "Stitches::ValidMimeType", except: %r{/super-secret}
+config.app_middleware.use Stitches::ApiKey, except: %r{/super-secret}
+config.app_middleware.use Stitches::ValidMimeType, except: %r{/super-secret}
 # or whatever you want to do
 ```
 

--- a/lib/stitches/railtie.rb
+++ b/lib/stitches/railtie.rb
@@ -3,7 +3,7 @@ require 'stitches/valid_mime_type'
 
 module Stitches
   class Railtie < Rails::Railtie
-    config.app_middleware.use "Stitches::ApiKey"
-    config.app_middleware.use "Stitches::ValidMimeType"
+    config.app_middleware.use Stitches::ApiKey
+    config.app_middleware.use Stitches::ValidMimeType
   end
 end


### PR DESCRIPTION
- Prefer constants over strings

> Passing strings or symbols to the middleware builder is deprecated,
change them to actual class references

https://github.com/rails/rails/commit/83b767ce