### PR TITLE
use Rails 5 migrations format

### DIFF
--- a/lib/stitches/generator_files/db/migrate/add_enabled_to_api_clients.rb
+++ b/lib/stitches/generator_files/db/migrate/add_enabled_to_api_clients.rb
@@ -1,4 +1,8 @@
+<% if Rails::VERSION::MAJOR >= 5 %>
+class AddEnabledToApiClients < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+<% else %>
 class AddEnabledToApiClients < ActiveRecord::Migration
+<% end %>
   def change
     add_column :api_clients, :enabled, :bool, null: false, default: true
     remove_index :api_clients, [:name ] # existing one would be unique

--- a/lib/stitches/generator_files/db/migrate/create_api_clients.rb
+++ b/lib/stitches/generator_files/db/migrate/create_api_clients.rb
@@ -1,4 +1,8 @@
+<% if Rails::VERSION::MAJOR >= 5 %>
+class CreateApiClients < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+<% else %>
 class CreateApiClients < ActiveRecord::Migration
+<% end %>
   def change
     create_table :api_clients do |t|
       t.string :name, null: false

--- a/lib/stitches/generator_files/db/migrate/enable_uuid_ossp_extension.rb
+++ b/lib/stitches/generator_files/db/migrate/enable_uuid_ossp_extension.rb
@@ -1,4 +1,8 @@
+<% if Rails::VERSION::MAJOR >= 5 %>
+class EnableUuidOsspExtension < ActiveRecord::Migration[<%= Rails::VERSION::MAJOR %>.<%= Rails::VERSION::MINOR %>]
+<% else %>
 class EnableUuidOsspExtension < ActiveRecord::Migration
+<% end %>
   def change
     enable_extension 'uuid-ossp'
   end


### PR DESCRIPTION
# Problem

The `migration_template` doesn't insert Rails 5's new versioning into the migrations, meaning they don't work on Rails 5 apps.

# Solution

Check the version of rails and use them if we are on 5 or greater

This was tested locally and works as desired.  This gem could use a better test suite.