### PR TITLE
fix method name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ class Api::V1::WidgetsController < ApiController
       head 201
     else
       render json: { 
-        errors: Stitches::Errors.from_active_record(widget) 
+        errors: Stitches::Errors.from_active_record_object(widget) 
       }, status: 422
     end
   end


### PR DESCRIPTION
The README gives an error-handling example with `::from_active_record` but the method is actually `::from_active_record_object`: https://github.com/stitchfix/stitches/blob/0052c7052fea38c32fc3e73c51a2558bfe5929ef/lib/stitches/errors.rb#L70