### PR TITLE
Add rescue_from StandardError to ApiController generator file to create Stitches error objects

### DIFF
--- a/lib/stitches/generator_files/app/controllers/api/api_controller.rb
+++ b/lib/stitches/generator_files/app/controllers/api/api_controller.rb
@@ -1,10 +1,20 @@
 class Api::ApiController < ActionController::Base
   include Stitches::Deprecation
+  #
+  # The order of the rescue_from blocks is important - ActiveRecord::RecordNotFound must come after StandardError,
+  # otherwise "not_found" errors will get rescued in the StandardError block.
+  # See the documentation for rescue_from for further explanation:
+  # https://apidock.com/rails/ActiveSupport/Rescuable/ClassMethods/rescue_from
+  # Specifically, this part: "Handlers are inherited. They are searched from right to left, from bottom to top, and up
+  # the hierarchy."
+  #
+  rescue_from StandardError do |exception|
+    Bugsnag.notify(exception)
+    render json: { errors: Stitches::Errors.from_exception(exception) }, status: :internal_server_error
+  end
+
   rescue_from ActiveRecord::RecordNotFound do |exception|
-    respond_to do |type|
-      type.json { render json: { errors: Stitches::Errors.new([ Stitches::Error.new(code: "not_found", message: exception.message) ]) }, status: 404 }
-      type.all  { render :nothing => true, :status => 404 }
-    end
+    render json: { errors: Stitches::Errors.new([ Stitches::Error.new(code: "not_found", message: exception.message) ]) }, status: :not_found
   end
 
   def current_user

--- a/lib/stitches/generator_files/app/controllers/api/api_controller.rb
+++ b/lib/stitches/generator_files/app/controllers/api/api_controller.rb
@@ -9,7 +9,6 @@ class Api::ApiController < ActionController::Base
   # the hierarchy."
   #
   rescue_from StandardError do |exception|
-    Bugsnag.notify(exception)
     render json: { errors: Stitches::Errors.from_exception(exception) }, status: :internal_server_error
   end
 

--- a/lib/stitches/generator_files/app/controllers/api/api_controller.rb
+++ b/lib/stitches/generator_files/app/controllers/api/api_controller.rb
@@ -2,7 +2,7 @@ class Api::ApiController < ActionController::Base
   include Stitches::Deprecation
   #
   # The order of the rescue_from blocks is important - ActiveRecord::RecordNotFound must come after StandardError,
-  # otherwise "not_found" errors will get rescued in the StandardError block.
+  # otherwise ActiveRecord::RecordNotFound exceptions will get rescued in the StandardError block.
   # See the documentation for rescue_from for further explanation:
   # https://apidock.com/rails/ActiveSupport/Rescuable/ClassMethods/rescue_from
   # Specifically, this part: "Handlers are inherited. They are searched from right to left, from bottom to top, and up
@@ -13,7 +13,7 @@ class Api::ApiController < ActionController::Base
   end
 
   rescue_from ActiveRecord::RecordNotFound do |exception|
-    render json: { errors: Stitches::Errors.new([ Stitches::Error.new(code: "not_found", message: exception.message) ]) }, status: :not_found
+    render json: { errors: Stitches::Errors.from_exception(exception) }, status: :not_found
   end
 
   def current_user

--- a/spec/integration/add_to_rails_app_spec.rb
+++ b/spec/integration/add_to_rails_app_spec.rb
@@ -75,6 +75,8 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
       expect(File.read(rails_root / "spec" / "rails_helper.rb")).to include("require 'rspec_api_documentation'")
       expect(File.read(rails_root / "config" / "initializers" / "apitome.rb")).to include("config.mount_at = nil")
       expect(File.read(rails_root / "config" / "initializers" / "apitome.rb")).to include("config.title = 'Service Documentation'")
+      expect(File.read(rails_root / "app" / "controllers" / "api" / "api_controller.rb")).to include("rescue_from StandardError")
+      expect(File.read(rails_root / "app" / "controllers" / "api" / "api_controller.rb")).to include("rescue_from ActiveRecord::RecordNotFound")
     end
   end
 


### PR DESCRIPTION
## Problem

By default, new services created by Stitches only create `Stitches` error objects for `404` errors and not any other types of errors.

If creating `Stitches` errors for all types of errors isn't set up manually, consumers of the service will get a response body in an unexpected format and may not be able to parse it correctly to do whatever is needed with the error.

## Solution

Add `rescue_from StandardError` to the `ApiController` generator file, and create a `Stitches` error from the exception. Also report the exception to `Bugsnag` so that it's not swallowed by rescuing it.

This solution is inspired by [this discussion in the Item Price Service](https://github.com/stitchfix/item-price-service/pull/20/files#r216887615).

## Deployment Steps

### Post-Deployment

- [ ] Run `rake version:minor` and `rake release`