### PR TITLE
Bump version to 3.7.1

### DIFF
--- a/lib/stitches/version.rb
+++ b/lib/stitches/version.rb
@@ -1,3 +1,3 @@
 module Stitches
-  VERSION = '3.6.1'
+  VERSION = '3.7.1'
 end


### PR DESCRIPTION
## Problem

I didn't realize I needed to manually bump the version for the changes in #62. The tasks we normally use to do this are from a private Stitch Fix gem (`y`), which is not included in `stitches`.

## Solution

Bump the version from `3.6.1` to `3.7.1`, since it's a minor release. After deploying, I will run the `rake release` task.