### PR TITLE
remove image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,5 +118,3 @@ any fancy refactors here, just keep it up to date.
 ---
 
 Provided with love by your friends at [Stitch Fix Engineering](http://technology.stitchfix.com)
-
-![stitches](https://s3.amazonaws.com/stitchfix-stitches/stitches.png)


### PR DESCRIPTION
This image is the single file in a public S3 legacy bucket.  We would like to delete the bucket if possible.  If this image *really* needs to exist, could we possibly put it in this repo?