### PR TITLE
Fix error when validations fail on nested attributes.

### DIFF
--- a/lib/stitches/errors.rb
+++ b/lib/stitches/errors.rb
@@ -70,7 +70,7 @@ module Stitches
     def self.from_active_record_object(object)
       errors = object.errors.to_hash.map { |field,errors|
         code = "#{field}_invalid".parameterize
-        message = if object.send(field).respond_to?(:errors)
+        message = if object.respond_to?(field) && object.send(field).respond_to?(:errors)
                     object.send(field).errors.full_messages.sort.join(', ')
                   else
                     object.errors.full_messages_for(field).sort.join(', ')

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -94,6 +94,13 @@ describe Stitches::Errors do
       expect(errors_hash[1]["code"]).to eq("person_invalid")
       expect(errors_hash[1]["message"]).to eq("Age is not a number, First name can't be blank, Last name starts with z.")
     end
+
+    it "works with nested attributes" do
+      object.errors.add("something.nested", "is required")
+      errors = Stitches::Errors.from_active_record_object(object)
+      errors_hash = JSON.parse(errors.to_json).sort_by {|_| _["code"] }
+      expect(errors_hash[0]["code"]).to eq("something-nested_invalid")
+      expect(errors_hash[0]["message"]).to eq("Something nested is required")
+    end
   end
 end
-


### PR DESCRIPTION
## Problem

When submitting nested attributes for an object, and there is a validation error on the nested object you are trying to update, `Stitches::Errors.from_active_record_object` throws an error along the lines of

```
NoMethodError (undefined method `style_variants.order' for #<Style:0x00007fe0a07600d8>
Did you mean?  style_variants):
```

## Solution

Before sending the field name to the object, make sure it responds to it first.