### PR TITLE
update deprecation warning to match ADR

### DIFF
--- a/lib/stitches/deprecation.rb
+++ b/lib/stitches/deprecation.rb
@@ -19,7 +19,7 @@ module Stitches
     #     end
     def deprecated(gone_on:,&block)
       response.set_header("Sunset",Date.parse(gone_on).in_time_zone("GMT").midnight.strftime("%a, %e %b %Y %H:%M:%S %Z"))
-      Rails.logger.info("Deprecated endpoint #{request.method} #{request.fullpath} requested by #{current_user.id}")
+      Rails.logger.info("DEPRECATED ENDPOINT #{request.method} to #{request.fullpath} requested by #{current_user.id}")
       block.()
     end
   end

--- a/spec/deprecation_spec.rb
+++ b/spec/deprecation_spec.rb
@@ -32,7 +32,7 @@ describe Stitches::Deprecation do
     end
     it "logs about the request and current API key id" do
       fake_controller.deprecated(gone_on: "2018-01-01") {}
-      expect(logger).to have_received(:info).with(/deprecated.*#{Regexp.escape(request.method)}.*#{Regexp.escape(request.fullpath)}.*#{Regexp.escape(api_client.id.to_s)}/i)
+      expect(logger).to have_received(:info).with(/DEPRECATED.*#{Regexp.escape(request.method)}.*#{Regexp.escape(request.fullpath)}.*#{Regexp.escape(api_client.id.to_s)}/i)
     end
     it "executes and returns the block" do
       block_executed = false


### PR DESCRIPTION
Minor update to warning message to match the ADR for deprecating endpoints

https://github.com/stitchfix/eng-wiki/blob/master/technical-topics/microservice-api-deprecation-policy.md