### PR TITLE
Update the ApiController to inherit from ActionController::API

### DIFF
--- a/lib/stitches/generator_files/app/controllers/api/api_controller.rb
+++ b/lib/stitches/generator_files/app/controllers/api/api_controller.rb
@@ -1,4 +1,4 @@
-class Api::ApiController < ActionController::Base
+class Api::ApiController < ActionController::API
   include Stitches::Deprecation
   #
   # The order of the rescue_from blocks is important - ActiveRecord::RecordNotFound must come after StandardError,

--- a/lib/stitches/generator_files/app/controllers/api/v1/pings_controller.rb
+++ b/lib/stitches/generator_files/app/controllers/api/v1/pings_controller.rb
@@ -1,14 +1,10 @@
 class Api::V1::PingsController < Api::ApiController
 
   def create
-    respond_to do |format|
-      format.json do
-        if ping_params[:error]
-          render json: { errors: Stitches::Errors.new([ Stitches::Error.new(code: "test", message: ping_params[:error]) ])} , status: 422
-        else
-          render json: { ping: { status: "ok" } }, status: (ping_params[:status] || "201").to_i
-        end
-      end
+    if ping_params[:error]
+      render json: { errors: Stitches::Errors.new([ Stitches::Error.new(code: "test", message: ping_params[:error]) ])} , status: 422
+    else
+      render json: { ping: { status: "ok" } }, status: (ping_params[:status] || "201").to_i
     end
   end
 

--- a/lib/stitches/generator_files/app/controllers/api/v2/pings_controller.rb
+++ b/lib/stitches/generator_files/app/controllers/api/v2/pings_controller.rb
@@ -1,14 +1,10 @@
 class Api::V2::PingsController < Api::ApiController
 
   def create
-    respond_to do |format|
-      format.json do
-        if ping_params[:error]
-          render json: { errors: Stitches::Errors.new([ Stitches::Error.new(code: "test", message: ping_params[:error]) ])} , status: 422
-        else
-          render json: { ping: { status_v2: "ok" } }, status: (ping_params[:status] || "201").to_i
-        end
-      end
+    if ping_params[:error]
+      render json: { errors: Stitches::Errors.new([ Stitches::Error.new(code: "test", message: ping_params[:error]) ])} , status: 422
+    else
+      render json: { ping: { status_v2: "ok" } }, status: (ping_params[:status] || "201").to_i
     end
   end
 


### PR DESCRIPTION
Problem
---
The **Api::ApiController** does not need to inherit from **[ActionController::Base](https://github.com/alexcameron89/rails/blob/9b0e632def6a66bbd0c0aba8531b2a173f7c3064/actionpack/lib/action_controller/base.rb#L205-L251)** since it does not provide support for browser requests.

We also only need to respond with JSON, so the `respond_to` blocks are
unnecessary.

Solution
---
Use Rails' thinner Controller base called **[ActionController::API](https://github.com/alexcameron89/rails/blob/9b0e632def6a66bbd0c0aba8531b2a173f7c3064/actionpack/lib/action_controller/api.rb#L112-L141)** which does not include many of the modules needed for browser support like CSRF protection, Flash, etc.

Because our API's only respond with JSON, we can take advantage of ActionController::API and remove the need for stuff like `respond_to` blocks and `skip :verify_authenticity_token`.

Question
---
Should I go ahead and bump the minor version with this change?