### PR TITLE
Add CODEOWNERS file.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+# THIS FILE IS NOT THE SOURCE OF TRUTH for app ownership. If this app
+# is transferred to another team, the app ownership should be changed
+# in fixops.
+#
+# View current canonical app ownership on Unwritten:
+# https://unwritten.stitchfix.com/docs/applications-and-services
+#
+# This file uses the GitHub CODEOWNERS convention to assign PR reviewers:
+# https://help.github.com/articles/about-codeowners/
+
+* @brettfishman @bwebster


### PR DESCRIPTION
## Problem

We currently lack clear ownership in many of our shared repositories.

## Solution

We'd like to take a step towards addressing this by having 2-3 (no more than 3) explicit owners for each of our shared repositories.  These individuals will be responsible for ensuring PRs receive timely and helpful review.
