### PR TITLE
Fix auth for services

### DIFF
--- a/lib/stitches/add_csrf_null_session_generator.rb
+++ b/lib/stitches/add_csrf_null_session_generator.rb
@@ -1,0 +1,21 @@
+require 'rails/generators'
+
+module Stitches
+  class AddCsrfNullSessionGenerator < Rails::Generators::Base
+    source_root(File.expand_path(File.join(File.dirname(__FILE__),"generator_files")))
+
+    desc "Fixes CSRF error on startup for a service created with an older version of stitches"
+    def add_csrf_null_session
+      inject_into_file "app/controllers/api/api_controller.rb", after: /^class.*$/ do
+        <<~CODE
+          #
+          # API clients pass an API key instead of a CSRF token; Use
+          # :null_session CSRF protection to avoid an auth error for these
+          # clients.
+          #
+          protect_from_forgery with: :null_session
+        CODE
+      end
+    end
+  end
+end

--- a/lib/stitches/generator_files/app/controllers/api/api_controller.rb
+++ b/lib/stitches/generator_files/app/controllers/api/api_controller.rb
@@ -1,4 +1,11 @@
 class Api::ApiController < ActionController::Base
+  #
+  # API clients pass an API key instead of a CSRF token; Use
+  # :null_session CSRF protection to avoid an auth error for these
+  # clients.
+  #
+  protect_from_forgery with: :null_session
+
   include Stitches::Deprecation
   #
   # The order of the rescue_from blocks is important - ActiveRecord::RecordNotFound must come after StandardError,

--- a/lib/stitches/version.rb
+++ b/lib/stitches/version.rb
@@ -1,3 +1,3 @@
 module Stitches
-  VERSION = '3.7.2'
+  VERSION = '3.7.3'
 end


### PR DESCRIPTION
The default Rails 5 template uses the `:exception` strategy for forgery protection; it raises an exception if a request doesn't contain a valid CSRF token.

This is a good default for user-facing apps, but for services it means that a freshly generated app will turn away all API requests—even ones with valid API keys.

This commit configures stitches-generated APIs to use the `:null_session` CSRF strategy for `ApiController` descendants—but retains the default `:exception` strategy for all other controllers.