### PR TITLE
Update the pull request template to remove steps specific to stitch fix internal gems

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -10,12 +10,9 @@
 
 ### Before Merging
 
-- [ ] If there is an RC on this branch, revert the version change in `version.rb`
+- [ ] Bump the version in `version.rb` following [SemVer](https://semver.org) **on this branch** (if you were testing an RC, make sure you remove the RC before merging)
 
 ### After Merging
 
-See the [gem release process](https://github.com/stitchfix/eng-wiki/blob/master/technical-topics/updating-gem-versions.md) for a detailed list, but the gist of it is:
-
-- [ ] Fetch `master` locally and run the applicable `rake version:*` task **on `master`** to bump the version
-- [ ] Run `rake release` **on `master`** to release the new version on Gemfury
+- [ ] Fetch `master` locally and run `rake release` **on `master`** to release the new version on Gemfury
 - [ ] Add [release notes](https://github.com/stitchfix/messaging/releases) - **this is very important in helping other engineers understand what changed in the new version**


### PR DESCRIPTION
## Problem

As mentioned in [this comment](https://github.com/stitchfix/stitches/pull/76#issuecomment-493226811) on #76, our standard Ruby gem PR template needs to be tweaked a little bit for open source gems, since the steps to release are slightly different.

## Solution

Update the PR template to remove references to the eng-wiki and the `stitchfix-y` gem (the release tasks), which are both internal.