### PR TITLE
Remove Apitome dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Then, set it up:
 
 ```
 > bin/rails generate rspec:install
-> bin/rails generate apitome:install
 > bin/rails generate stitches:api
 > bundle exec rake db:migrate
 ```

--- a/lib/stitches.rb
+++ b/lib/stitches.rb
@@ -1,4 +1,3 @@
 require 'stitches_norailtie'
 require 'stitches/railtie'
 # Add new stitches ruby files to the stitches_norailtie file instead of here
-require 'apitome'

--- a/lib/stitches/api_generator.rb
+++ b/lib/stitches/api_generator.rb
@@ -14,7 +14,6 @@ module Stitches
     def bootstrap_api
       inject_into_file "Gemfile", after: /^gem ['"]rails['"].*$/ do<<-GEM
 
-gem "apitome"
 gem "responders"
 gem "rspec_api_documentation", group: [ :development, :test ]
 gem "capybara", group: [ :development, :test ]
@@ -32,10 +31,6 @@ namespace :api do
     # as well as for your client to be able to validate this as well.
   end
 end
-api_docs = Rack::Auth::Basic.new(Apitome::Engine ) do |_,password|
-  password == ENV['HTTP_AUTH_PASSWORD']
-end
-mount api_docs, at: "docs"
       ROUTES
       end
 
@@ -86,10 +81,6 @@ config.api_name = "YOUR SERVICE NAME HERE"
 end
       RSPEC_API
       end
-      run "rails g apitome:install"
-      gsub_file 'config/initializers/apitome.rb', /config.mount_at = .*$/, "config.mount_at = nil"
-      gsub_file 'config/initializers/apitome.rb', /config.title = .*$/, "config.title = 'Service Documentation'"
-
     end
   end
 end

--- a/spec/integration/add_to_rails_app_spec.rb
+++ b/spec/integration/add_to_rails_app_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
 
   it "works as described in the README" do
     run "bin/rails generate rspec:install"
-    run "bin/rails generate apitome:install"
     run "bin/rails generate stitches:api"
 
     rails_root = Pathname(work_dir) / rails_app_name
@@ -59,13 +58,11 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
     # It's also in one big block because making a new rails app and running the generator multiple times seems bad.
     aggregate_failures do
       expect(File.exist?(rails_root / "app" / "controllers" / "api" / "api_controller.rb")).to eq(true)
-      expect(rails_root / "Gemfile").to contain_gem("apitome")
       expect(rails_root / "Gemfile").to contain_gem("responders")
       expect(rails_root / "Gemfile").to contain_gem("rspec_api_documentation")
       expect(rails_root / "Gemfile").to contain_gem("capybara")
       expect(rails_root / "config" / "routes.rb").to have_route(namespace: :api, module_scope: :v1, resource: 'ping')
       expect(rails_root / "config" / "routes.rb").to have_route(namespace: :api, module_scope: :v2, resource: 'ping')
-      expect(rails_root / "config" / "routes.rb").to have_mounted_engine("Apitome::Engine")
       migrations = Dir["#{rails_root}/db/migrate/*.rb"].sort
       expect(migrations.size).to eq(2)
       expect(migrations[0]).to match(/\/\d+_enable_uuid_ossp_extension.rb/)
@@ -73,8 +70,6 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
       expect(File.read(rails_root / "spec" / "rails_helper.rb")).to include("config.include RSpec::Rails::RequestExampleGroup, type: :feature")
       expect(File.read(rails_root / "spec" / "rails_helper.rb")).to include("require 'stitches/spec'")
       expect(File.read(rails_root / "spec" / "rails_helper.rb")).to include("require 'rspec_api_documentation'")
-      expect(File.read(rails_root / "config" / "initializers" / "apitome.rb")).to include("config.mount_at = nil")
-      expect(File.read(rails_root / "config" / "initializers" / "apitome.rb")).to include("config.title = 'Service Documentation'")
       expect(File.read(rails_root / "app" / "controllers" / "api" / "api_controller.rb")).to include("rescue_from StandardError")
       expect(File.read(rails_root / "app" / "controllers" / "api" / "api_controller.rb")).to include("rescue_from ActiveRecord::RecordNotFound")
     end
@@ -82,7 +77,6 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
 
   it "inserts the deprecation module into ApiController" do
     run "bin/rails generate rspec:install"
-    run "bin/rails generate apitome:install"
     run "bin/rails generate stitches:api"
 
     rails_root = Pathname(work_dir) / rails_app_name
@@ -107,7 +101,6 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
 
   it "inserts can update old configuration" do
     run "bin/rails generate rspec:install"
-    run "bin/rails generate apitome:install"
     run "bin/rails generate stitches:api"
 
     rails_root = Pathname(work_dir) / rails_app_name

--- a/stitches.gemspec
+++ b/stitches.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("pg")
   s.add_runtime_dependency("rspec", ">= 3")
   s.add_runtime_dependency("rspec-rails", "~> 3")
-  s.add_runtime_dependency("apitome")
 
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec_junit_formatter")


### PR DESCRIPTION
## Problem

[Apitome](https://github.com/jejacks0n/apitome) is used to serve the API documentation in production, which means an otherwise API-only application needs extra dependencies such as `ActionView` and `Nokogiri`.

## Solution

This removes Apitome (hosts docs generated by rspec_api_documentation)
from the generator and gem and thereby permits applications that use
stitches to opt-out of hosting the documentation.

Hosting the documentation in production requires an otherwise API-only
application to include dependencies such as ActionView and Nokogiri.
Viewing documentation is a relatively infrequent thing and only helps
developers who also have access to Github, so the suggested alternative
is to view the generated documentation locally:

```sh
# Generate the docs if they don't already exist
$ RAILS_ENV=test bin/rails docs:generate
$ open docs/api/index.html
```

This change should not impact applications using Apitome since it's already explicitly added to their Gemfile.

## Checklist

### Before Merging

- [ ] Bump the version in `version.rb` following [SemVer](https://semver.org) **on this branch** (if you were testing an RC, make sure you remove the RC before merging)

### After Merging

- [ ] Fetch `master` locally and run `rake release` **on `master`** to release the new version on Gemfury
- [ ] Add [release notes](https://github.com/stitchfix/messaging/releases) - **this is very important in helping other engineers understand what changed in the new version**
