### PR TITLE
Headers respond with the correct version

### DIFF
--- a/lib/stitches/railtie.rb
+++ b/lib/stitches/railtie.rb
@@ -1,9 +1,11 @@
 require 'stitches/api_key'
 require 'stitches/valid_mime_type'
+require 'stitches/response_header'
 
 module Stitches
   class Railtie < Rails::Railtie
     config.app_middleware.use Stitches::ApiKey
     config.app_middleware.use Stitches::ValidMimeType
+    config.app_middleware.use Stitches::ResponseHeader
   end
 end

--- a/lib/stitches/response_header.rb
+++ b/lib/stitches/response_header.rb
@@ -1,0 +1,12 @@
+require_relative 'allowlist_middleware'
+
+module Stitches
+  class ResponseHeader < Stitches::AllowlistMiddleware
+  protected
+    def do_call(env)
+      status, headers, body = @app.call(env)
+      headers["Content-Type"] = env["CONTENT_TYPE"]
+      [status, headers, body]
+    end
+  end
+end

--- a/lib/stitches/version.rb
+++ b/lib/stitches/version.rb
@@ -1,3 +1,3 @@
 module Stitches
-  VERSION = '3.7.3'
+  VERSION = '3.8.3'
 end

--- a/spec/response_header_spec.rb
+++ b/spec/response_header_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper.rb'
+
+describe Stitches::ResponseHeader do
+    let(:app) { double("rack app") }
+    let(:headers) { {"Content-Type" => ""} }
+
+    before do
+      allow(app).to receive(:call).with(env).and_return([nil, headers, nil])
+    end
+
+    subject(:middleware) { described_class.new(app, namespace: "/api") }
+
+    describe "#call" do
+      context "valid header" do
+        let(:env) {
+          {
+            "PATH_INFO" => "/api/ping",
+            "HTTP_ACCEPT" => "application/json; version=99",
+            "CONTENT_TYPE" => "application/json; version=99"
+          }
+        }
+
+        before do
+          @response = middleware.call(env)
+        end
+        it "calls through to the rest of the chain" do
+          expect(app).to have_received(:call).with(env)
+        end
+
+        it "has the Content-Type version information" do
+           expect(@response[1]["Content-Type"]).to eq("application/json; version=99")
+        end
+      end
+    end
+  end


### PR DESCRIPTION
## Problem

This resolves #70. Response headers do not respond with the correct version. 

## Solution

This adds a rack middleware that overrides the Content-Type header to show the version. 

## Checklist

### Before Merging

- [ ] Bump the version in `version.rb` following [SemVer](https://semver.org) **on this branch** (if you were testing an RC, make sure you remove the RC before merging)

### After Merging

- [ ] Fetch `master` locally and run `rake release` **on `master`** to release the new version on Gemfury
- [ ] Add [release notes](https://github.com/stitchfix/messaging/releases) - **this is very important in helping other engineers understand what changed in the new version**
