### PR TITLE
Remove reference to versioning and releasing

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,14 +5,3 @@
 ## Solution
 
 «Brief description of how you solved the problem»
-
-## Checklist
-
-### Before Merging
-
-- [ ] Bump the version in `version.rb` following [SemVer](https://semver.org) **on this branch** (if you were testing an RC, make sure you remove the RC before merging)
-
-### After Merging
-
-- [ ] Fetch `master` locally and run `rake release` **on `master`** to release the new version on Gemfury
-- [ ] Add [release notes](https://github.com/stitchfix/messaging/releases) - **this is very important in helping other engineers understand what changed in the new version**


### PR DESCRIPTION
## Problem

This repo is open-source, but the pull request template references a process that we don't expect OS contributors to follow.

## Solution

Remove references to versioning and releasing new versions of this gem.

## Checklist

### Before Merging

- [ ] Bump the version in `version.rb` following [SemVer](https://semver.org) **on this branch** (if you were testing an RC, make sure you remove the RC before merging)

### After Merging

- [ ] Fetch `master` locally and run `rake release` **on `master`** to release the new version on Gemfury
- [ ] Add [release notes](https://github.com/stitchfix/messaging/releases) - **this is very important in helping other engineers understand what changed in the new version**
