### PR TITLE
Rely on inserted gem dependencies rather than have them as runtime gem dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ config/database.yml
 .jhw-cache
 **.orig
 Gemfile.lock
+Gemfile.*.lock
 .projections.json

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ bundle install
 Then, set it up:
 
 ```
-> bin/rails generate rspec:install
-> bin/rails generate apitome:install
 > bin/rails generate stitches:api
 > bundle exec rake db:migrate
 ```

--- a/lib/stitches.rb
+++ b/lib/stitches.rb
@@ -1,4 +1,2 @@
 require 'stitches_norailtie'
 require 'stitches/railtie'
-# Add new stitches ruby files to the stitches_norailtie file instead of here
-require 'apitome'

--- a/lib/stitches/api_generator.rb
+++ b/lib/stitches/api_generator.rb
@@ -14,7 +14,6 @@ module Stitches
     def bootstrap_api
       gem "stitches"
       gem "apitome"
-      gem "responders"
       gem_group :development, :test do
         gem "rspec"
         gem "rspec-rails"

--- a/lib/stitches/api_generator.rb
+++ b/lib/stitches/api_generator.rb
@@ -4,7 +4,7 @@ module Stitches
   class ApiGenerator < Rails::Generators::Base
     include Rails::Generators::Migration
 
-    source_root(File.expand_path(File.join(File.dirname(__FILE__),"generator_files")))
+    source_root(File.expand_path(File.join(File.dirname(__FILE__), "generator_files")))
 
     def self.next_migration_number(path)
       Time.now.utc.strftime("%Y%m%d%H%M%S")
@@ -12,14 +12,22 @@ module Stitches
 
     desc "Bootstraps your API service with a basic ping controller and spec to ensure everything is setup properly"
     def bootstrap_api
-      inject_into_file "Gemfile", after: /^gem ['"]rails['"].*$/ do<<-GEM
-
-gem "apitome"
-gem "responders"
-gem "rspec_api_documentation", group: [ :development, :test ]
-gem "capybara", group: [ :development, :test ]
-      GEM
+      gem "stitches"
+      gem "apitome"
+      gem "responders"
+      gem_group :development, :test do
+        gem "rspec"
+        gem "rspec-rails"
+        gem "rspec_api_documentation"
       end
+
+      run "bundle install"
+      generate "apitome:install"
+      generate "rspec:install"
+
+      gsub_file 'config/initializers/apitome.rb', /config.mount_at = .*$/, "config.mount_at = nil"
+      gsub_file 'config/initializers/apitome.rb', /config.title = .*$/, "config.title = 'Service Documentation'"
+
       inject_into_file "config/routes.rb", before: /^end/ do<<-ROUTES
 namespace :api do
   scope module: :v1, constraints: Stitches::ApiVersionConstraint.new(1) do
@@ -32,14 +40,13 @@ namespace :api do
     # as well as for your client to be able to validate this as well.
   end
 end
-api_docs = Rack::Auth::Basic.new(Apitome::Engine ) do |_,password|
+
+api_docs = Rack::Auth::Basic.new(Apitome::Engine) do |_, password|
   password == ENV['HTTP_AUTH_PASSWORD']
 end
 mount api_docs, at: "docs"
       ROUTES
       end
-
-      run 'bundle install'
 
       copy_file "app/controllers/api.rb"
       copy_file "app/controllers/api/api_controller.rb"
@@ -52,8 +59,6 @@ mount api_docs, at: "docs"
       copy_file "lib/tasks/generate_api_key.rake"
       template "spec/features/api_spec.rb.erb", "spec/features/api_spec.rb"
       copy_file "spec/acceptance/ping_v1_spec.rb", "spec/acceptance/ping_v1_spec.rb"
-
-      run 'bundle install'
 
       migration_template "db/migrate/enable_uuid_ossp_extension.rb", "db/migrate/enable_uuid_ossp_extension.rb"
       sleep 1 # allow clock to tick so we get different numbers
@@ -70,26 +75,23 @@ require 'stitches/spec'
 
       append_to_file 'spec/rails_helper.rb' do<<-RSPEC_API
 require 'rspec_api_documentation'
-RspecApiDocumentation.configure do |config|
-config.format = :json
-config.request_headers_to_include = %w(
-  Accept
-  Content-Type
-  Authorization
-  If-Modified-Since
-)
-config.response_headers_to_include = %w(
-  Last-Modified
-  ETag
-)
-config.api_name = "YOUR SERVICE NAME HERE"
-end
-      RSPEC_API
-      end
-      run "rails g apitome:install"
-      gsub_file 'config/initializers/apitome.rb', /config.mount_at = .*$/, "config.mount_at = nil"
-      gsub_file 'config/initializers/apitome.rb', /config.title = .*$/, "config.title = 'Service Documentation'"
 
+RspecApiDocumentation.configure do |config|
+  config.format = :json
+  config.request_headers_to_include = %w(
+    Accept
+    Content-Type
+    Authorization
+    If-Modified-Since
+  )
+  config.response_headers_to_include = %w(
+    Last-Modified
+    ETag
+  )
+  config.api_name = "YOUR SERVICE NAME HERE"
+end
+RSPEC_API
+      end
     end
   end
 end

--- a/spec/integration/add_to_rails_app_spec.rb
+++ b/spec/integration/add_to_rails_app_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
 
         FileUtils.chdir rails_app_name do
           run use_local_stitches
+          # It's unclear why, but on CI the gems are not found when installed
+          # through bundler however installing them explicitly first fixes it.
           run "gem install apitome rspec-rails rspec_api_documentation"
           run "bundle install"
           example.run

--- a/spec/integration/add_to_rails_app_spec.rb
+++ b/spec/integration/add_to_rails_app_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
   let(:rails_app_name) { "swamp-thing" }
 
   def run(command)
-    stdout, stderr, stat = Bundler.with_original_env { Open3.capture3({ 'BUNDLE_GEMFILE' => 'Gemfile' }, command) }
+    stdout, stderr, stat = Bundler.with_clean_env { Open3.capture3({ 'BUNDLE_GEMFILE' => 'Gemfile' }, command) }
     success = stat.success? && stdout !~ /Could not find generator/im
 
     if ENV["DEBUG"] == 'true' || !success
@@ -48,6 +48,7 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
       FileUtils.chdir rails_app_name do
         run use_local_stitches
         run "bundle install"
+        run "gem install apitome responders rspec-rails rspec_api_documentation"
         example.run
       end
     end

--- a/spec/integration/add_to_rails_app_spec.rb
+++ b/spec/integration/add_to_rails_app_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
 
         FileUtils.chdir rails_app_name do
           run use_local_stitches
-          run "gem install apitome responders rspec-rails rspec_api_documentation"
+          run "gem install apitome rspec-rails rspec_api_documentation"
           run "bundle install"
           example.run
         end
@@ -68,9 +68,7 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
     aggregate_failures do
       expect(File.exist?(rails_root / "app" / "controllers" / "api" / "api_controller.rb")).to eq(true)
       expect(rails_root / "Gemfile").to contain_gem("apitome")
-      expect(rails_root / "Gemfile").to contain_gem("responders")
       expect(rails_root / "Gemfile").to contain_gem("rspec_api_documentation")
-      expect(rails_root / "Gemfile").to contain_gem("capybara")
       expect(rails_root / "config" / "routes.rb").to have_route(namespace: :api, module_scope: :v1, resource: 'ping')
       expect(rails_root / "config" / "routes.rb").to have_route(namespace: :api, module_scope: :v2, resource: 'ping')
       expect(rails_root / "config" / "routes.rb").to have_mounted_engine("Apitome::Engine")

--- a/spec/integration/add_to_rails_app_spec.rb
+++ b/spec/integration/add_to_rails_app_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
   let(:rails_app_name) { "swamp-thing" }
 
   def run(command)
-    stdout, stderr, stat = Bundler.with_original_env { Open3.capture3(command) }
+    stdout, stderr, stat = Bundler.with_original_env { Open3.capture3({ 'BUNDLE_GEMFILE' => 'Gemfile' }, command) }
     success = stat.success? && stdout !~ /Could not find generator/im
 
     if ENV["DEBUG"] == 'true' || !success

--- a/stitches.gemspec
+++ b/stitches.gemspec
@@ -20,10 +20,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("rails")
   s.add_runtime_dependency("pg")
-  s.add_runtime_dependency("rspec", ">= 3")
-  s.add_runtime_dependency("rspec-rails", "~> 3")
-  s.add_runtime_dependency("apitome")
 
+  s.add_development_dependency("rspec", ">= 3")
   s.add_development_dependency("rake")
   s.add_development_dependency("rspec_junit_formatter")
 end


### PR DESCRIPTION
## Problem

`spec/integration/add_to_rails_app_spec.rb` is intending on testing the app as it would be used according to the README, however the application setup in the tests isn't including the `stitches` gem in it's `Gemfile`. The consequence is that even though `stitches` is adding `apitome` to the application's Gemfile, it must also be listed as a runtime dependency.

The gem inserts "apitome" and "rspec-rails" (now adds, rather than assuming it
already there) and within the gem context of the application executes
the generators and updates the files.


## Solution

- Update the test application to include the local copy of `stitches`
- Run `bin/rails generate rspec:install` and `bin/rails generate apitome:install` as part of `bin/rails generate stitches:api` since they are implicit dependencies.  An alternative would be to detect if the `rails_helper` or `apitome` initializer exist before attempting to update them.
- Remove Apitome as a runtime dependency
- Move RSpec from a runtime dependency to a development dependency