### PR TITLE
Resolve DEPRECATION WARNINGs for Rails.application.class.parent

### DIFF
--- a/lib/stitches/api_key.rb
+++ b/lib/stitches/api_key.rb
@@ -22,7 +22,7 @@ module Stitches
 
     def initialize(app,options = {})
       super(app,options)
-      @realm = Rails.application.class.parent.to_s
+      @realm = Rails.application.class.module_parent.to_s
     end
 
   protected

--- a/lib/stitches/api_key.rb
+++ b/lib/stitches/api_key.rb
@@ -22,7 +22,7 @@ module Stitches
 
     def initialize(app,options = {})
       super(app,options)
-      @realm = Rails.application.class.module_parent.to_s
+      @realm = rails_app_module
     end
 
   protected
@@ -56,6 +56,12 @@ module Stitches
     end
 
   private
+
+    def rails_app_module
+      application_class = Rails.application.class
+      parent = application_class.try(:module_parent) || application_class.parent
+      parent.to_s
+    end
 
     class UnauthorizedResponse < Rack::Response
       def initialize(reason,realm,custom_http_auth_scheme)

--- a/lib/stitches/api_key.rb
+++ b/lib/stitches/api_key.rb
@@ -57,6 +57,11 @@ module Stitches
 
   private
 
+    # TODO: (jdlubrano)
+    # Once Rails 5 support is no longer necessary, we can simply call
+    # Rails.application.class.module_parent.  The module_parent method
+    # does not exist in Rails <= 5, though, so we need to gracefully fallback
+    # Rails.application.class.parent for Rails versions predating Rails 6.0.0.
     def rails_app_module
       application_class = Rails.application.class
       parent = application_class.try(:module_parent) || application_class.parent

--- a/lib/stitches/generator_files/spec/features/api_spec.rb.erb
+++ b/lib/stitches/generator_files/spec/features/api_spec.rb.erb
@@ -123,14 +123,22 @@ feature "general API stuff" do
     failure_message do
       correct_code,_ = evaluate_response(response)
       if correct_code
-        "Expected WWW-Authenticate header to be 'CustomKeyAuth realm=#{Rails.application.class.parent.to_s}', but was #{response['WWW-Authenticate']}"
+        "Expected WWW-Authenticate header to be 'CustomKeyAuth realm=#{realm}', but was #{response['WWW-Authenticate']}"
       else
         "Expected response to be 401, but was #{response.response_code}"
       end
     end
 
+    def realm
+<% if ::Rails::VERSION::MAJOR >= 6 -%>
+     Rails.application.class.module_parent.to_s
+<% else %>
+     Rails.application.class.parent.to_s
+<% end %>
+    end
+
     def evaluate_response(response)
-      [response.response_code == 401, response.headers["WWW-Authenticate"] == "CustomKeyAuth realm=#{Rails.application.class.parent.to_s}" ]
+      [response.response_code == 401, response.headers["WWW-Authenticate"] == "CustomKeyAuth realm=#{realm}"]
     end
   end
 end


### PR DESCRIPTION
## Problem

Upon upgrading other applications to Rails 6, I noticed some `DEPRECATION WARNING`s that were caused by calls to `Module#parent` in this gem.

```
DEPRECATION WARNING: `Module#parent` has been renamed to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1. (called from initialize at /Users/joellubrano/Projects/stitch_fix/stitches/lib/stitches/api_key.rb:25)
```

Fixes #84 

## Solution

Removes/resolves the deprecation warning by cautiously replacing calls to `Module#parent` with `Module#module_parent`.

This change is safe as `Module#parent` calls `module_parent` in its
implementation.

Rails docs: https://edgeapi.rubyonrails.org/classes/Module.html#method-i-parent
Rails source: https://github.com/rails/rails/blob/0434e5ba23ab0d5b07e1d3802360cef626d3630e/activesupport/lib/active_support/core_ext/module/introspection.rb#L51