### PR TITLE
Add alias to_ary due to it being removed in rack update

### DIFF
--- a/lib/stitches/api_key.rb
+++ b/lib/stitches/api_key.rb
@@ -69,6 +69,8 @@ module Stitches
     end
 
     class UnauthorizedResponse < Rack::Response
+      alias to_ary finish
+
       def initialize(reason,realm,custom_http_auth_scheme)
         super("Unauthorized - #{reason}", 401, { "WWW-Authenticate" => "#{custom_http_auth_scheme} realm=#{realm}" })
       end


### PR DESCRIPTION
## Problem
`to_ary` was removed from `Response` In Rack's update from 2.0.8 to 2.1.1. Stitches inherits from this class and expected a `to_ary` method to be aliased to Response's finish method. 

## Solution
Add the alias that was removed from the update into our class `UnauthorizedResponse`