### PR TITLE
Small changes when using on a new app

### DIFF
--- a/lib/stitches/api_generator.rb
+++ b/lib/stitches/api_generator.rb
@@ -19,7 +19,9 @@ module Stitches
         gem "rspec_api_documentation"
       end
 
-      run "bundle install"
+      Bundler.with_clean_env do
+        run "bundle install"
+      end
       generate "apitome:install"
       generate "rspec:install"
 

--- a/lib/stitches/api_generator.rb
+++ b/lib/stitches/api_generator.rb
@@ -12,7 +12,6 @@ module Stitches
 
     desc "Bootstraps your API service with a basic ping controller and spec to ensure everything is setup properly"
     def bootstrap_api
-      gem "stitches"
       gem "apitome"
       gem_group :development, :test do
         gem "rspec"


### PR DESCRIPTION
## Problem

Fresh machine, fresh rails app (latest Rails 6), `bin/rails g stitches:api` fails in two ways

* The stitches gem is re-included, so it shows up twice in `Gemfile`, which makes `bundle install` fail or complain in red text
* `bundle install` fails for reasons I don't understand, but which is fixed with `Bundler.with_clean_env`.

## Solution

Make those changes.

I'm not sure how to add a failing test for this since the existing test suite passes but IRL the generator fails.

P.S. hope you are all doing well! ❤️ 