### PR TITLE
Prefer 'Regexp#match?' over 'Regexp#=~' when the result is not needed

### DIFF
--- a/lib/stitches/valid_mime_type.rb
+++ b/lib/stitches/valid_mime_type.rb
@@ -20,7 +20,7 @@ module Stitches
 
     def do_call(env)
       accept = String(env["HTTP_ACCEPT"])
-      if (accept =~ %r{application/json} && accept =~ %r{version=\d+}) || accept =~ %r{application/protobuf}
+      if (%r{application/json}.match?(accept) && %r{version=\d+}.match?(accept)) || %r{application/protobuf}.match?(accept)
         @app.call(env)
       else
         not_acceptable_response(accept)


### PR DESCRIPTION
## Problem

The [ValidMimeType](https://github.com/stitchfix/stitches/blob/225fbe44961a30c85f365d1b6d747a2af1bb7ade/lib/stitches/valid_mime_type.rb#L21-L28) middleware is allocating [`Matchdata`](https://ruby-doc.org/core-2.7.0/MatchData.html) objects but does not need them. Since the middleware runs on every request, I think it's worthwhile to optimize.

## Solution

Use [`Regexp#match?`](https://ruby-doc.org/core-2.7.0/Regexp.html#method-i-match-3F) instead.

Here's a benchmark script:
```ruby
# Usage: ruby regexp_bm.rb

require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'benchmark-memory'
end

# JSON
accept = "application/json"

Benchmark.ips do |b|
	b.time = 15
  b.report("=~ for json") do
    (accept =~ %r{application/json} && accept =~ %r{version=\d+}) || accept =~ %r{application/protobuf}
  end

  b.report(".match? for json") do
    (%r{application/json}.match?(accept) && %r{version=\d+}.match?(accept)) || %r{application/protobuf}.match?(accept)
  end

  b.compare!
end

# PROTOBUF
accept = "application/protobuf"
Benchmark.ips do |b|
	b.time = 15
  b.report("=~ for protobuf") do
    (accept =~ %r{application/json} && accept =~ %r{version=\d+}) || accept =~ %r{application/protobuf}
  end

  b.report(".match? for protobuf") do
    (%r{application/json}.match?(accept) && %r{version=\d+}.match?(accept)) || %r{application/protobuf}.match?(accept)
  end

  b.compare!
end

Benchmark.memory do |b|
  b.report("=~") do
    (accept =~ %r{application/json} && accept =~ %r{version=\d+}) || accept =~ %r{application/protobuf}
  end

  b.report(".match?") do
    (%r{application/json}.match?(accept) && %r{version=\d+}.match?(accept)) || %r{application/protobuf}.match?(accept)
  end

  b.compare!
end
```
Benchmark results on my machine:
```
07:06 $ ruby -v
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin19]

07:06 $ ruby regexp_bm.rb
Warming up --------------------------------------
         =~ for json    72.038k i/100ms
    .match? for json   328.950k i/100ms
Calculating -------------------------------------
         =~ for json    751.188k (± 1.5%) i/s -     11.310M in  15.059465s
    .match? for json      3.279M (± 1.0%) i/s -     49.342M in  15.050594s

Comparison:
    .match? for json:  3278753.1 i/s
         =~ for json:   751188.5 i/s - 4.36x  (± 0.00) slower

Warming up --------------------------------------
     =~ for protobuf    92.923k i/100ms
.match? for protobuf   398.059k i/100ms
Calculating -------------------------------------
     =~ for protobuf    935.759k (± 2.0%) i/s -     14.031M in  15.000566s
.match? for protobuf      3.975M (± 1.1%) i/s -     59.709M in  15.022371s

Comparison:
.match? for protobuf:  3975149.0 i/s
     =~ for protobuf:   935759.2 i/s - 4.25x  (± 0.00) slower

Calculating -------------------------------------
                  =~   208.000  memsize (   208.000  retained)
                         2.000  objects (     2.000  retained)
                         1.000  strings (     1.000  retained)
             .match?     0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
             .match?:          0 allocated
                  =~:        208 allocated - Infx more
```