### PR TITLE
Use time_precision setting for encoding TimeWithZone to json

### DIFF
--- a/lib/stitches/render_timestamps_in_iso8601_in_json.rb
+++ b/lib/stitches/render_timestamps_in_iso8601_in_json.rb
@@ -3,7 +3,7 @@ require 'active_support/time_with_zone'
 class ActiveSupport::TimeWithZone
   # We want dates to be a) in UTC and b) in ISO8601 always
   def as_json(options = {})
-    utc.iso8601
+    utc.iso8601(ActiveSupport.time_precision)
   end
 end
 


### PR DESCRIPTION
## Problem

Stitches overrides the `to_json` method on ActiveSupport::TimeWithZone objects but doesn't include sub-second precision even though that is the default in recent version of Rails.

## Solution

Rails 4.1 introduced a time_precision configuration that defaults to 3, but this invocation of iso8601 doesn't include any sub-second precision.

See ActiveSupport.time_precision or config.active_support.time_precision in:

https://guides.rubyonrails.org/configuring.html#configuring-active-support
