### PR TITLE
Redact full api key for expired key logging

### DIFF
--- a/lib/stitches/api_client_access_wrapper.rb
+++ b/lib/stitches/api_client_access_wrapper.rb
@@ -33,7 +33,7 @@ module Stitches::ApiClientAccessWrapper
 
     disabled_at = api_client.respond_to?(:disabled_at) ? api_client.disabled_at : nil
     if disabled_at && disabled_at > configuration.disabled_key_leniency_in_seconds.seconds.ago
-      message = "Allowing disabled ApiClient: #{api_client.name} with key #{api_client.key} disabled at #{disabled_at}"
+      message = "Allowing disabled ApiClient: #{api_client.name} with key #{redact_key(api_client)} disabled at #{disabled_at}"
       if disabled_at > configuration.disabled_key_leniency_error_log_threshold_in_seconds.seconds.ago
         logger.warn(message)
       else
@@ -41,9 +41,13 @@ module Stitches::ApiClientAccessWrapper
       end
       return api_client
     else
-      logger.error("Rejecting disabled ApiClient: #{api_client.name} with key #{api_client.key}")
+      logger.error("Rejecting disabled ApiClient: #{api_client.name} with key #{redact_key(api_client)}")
     end
     nil
+  end
+
+  def self.redact_key(api_client)
+    "*****#{api_client.key.to_s[-8..-1]}"
   end
 
   def self.logger

--- a/spec/api_key_middleware_spec.rb
+++ b/spec/api_key_middleware_spec.rb
@@ -102,10 +102,11 @@ RSpec.describe "/api/hellos", type: :request do
         context "when disabled_at is set to a time older than three days ago" do
           let(:disabled_at) { 4.day.ago }
 
-          it "allows the call" do
+          it "does not allow the call" do
             execute_call
 
             expect_unauthorized
+
           end
         end
 
@@ -162,7 +163,9 @@ RSpec.describe "/api/hellos", type: :request do
 
           it "logs error about the disabled key to the Rails.logger" do
             allow(Rails.logger).to receive(:warn)
-            allow(Rails.logger).to receive(:error)
+            allow(Rails.logger).to receive(:error) do |message1|
+              expect(message1).not_to include uuid
+            end
 
             execute_call
 
@@ -210,7 +213,10 @@ RSpec.describe "/api/hellos", type: :request do
             let(:disabled_at) { 101.seconds.ago }
 
             it "forbids the call" do
-              allow(Rails.logger).to receive(:error)
+              allow(Rails.logger).to receive(:error) do |message1|
+                expect(message1).not_to include uuid
+              end
+
               execute_call
 
               expect_unauthorized
@@ -235,7 +241,9 @@ RSpec.describe "/api/hellos", type: :request do
             let(:disabled_at) { 25.seconds.ago }
 
             it "allows the call" do
-              allow(Rails.logger).to receive(:warn)
+              allow(Rails.logger).to receive(:warn) do |message1|
+                expect(message1).not_to include uuid
+              end
 
               execute_call
 


### PR DESCRIPTION
## Problem

Expired keys would be logged in full if they were used, even during the grace period. It now seems better to log only part of the key due to security concerns.

## Solution

Only log the last few characters of the key, or none of it if it's quite short
