### PR TITLE
Remove apitome

### DIFF
--- a/lib/stitches/api_generator.rb
+++ b/lib/stitches/api_generator.rb
@@ -12,7 +12,6 @@ module Stitches
 
     desc "Bootstraps your API service with a basic ping controller and spec to ensure everything is setup properly"
     def bootstrap_api
-      gem "apitome"
       gem_group :development, :test do
         gem "rspec"
         gem "rspec-rails"
@@ -22,11 +21,7 @@ module Stitches
       Bundler.with_clean_env do
         run "bundle install"
       end
-      generate "apitome:install"
       generate "rspec:install"
-
-      gsub_file 'config/initializers/apitome.rb', /config.mount_at = .*$/, "config.mount_at = nil"
-      gsub_file 'config/initializers/apitome.rb', /config.title = .*$/, "config.title = 'Service Documentation'"
 
       inject_into_file "config/routes.rb", before: /^end/ do<<-ROUTES
 namespace :api do
@@ -40,11 +35,6 @@ namespace :api do
     # as well as for your client to be able to validate this as well.
   end
 end
-
-api_docs = Rack::Auth::Basic.new(Apitome::Engine) do |_, password|
-  password == ENV['HTTP_AUTH_PASSWORD']
-end
-mount api_docs, at: "docs"
       ROUTES
       end
 
@@ -77,7 +67,7 @@ require 'stitches/spec'
 require 'rspec_api_documentation'
 
 RspecApiDocumentation.configure do |config|
-  config.format = :json
+  config.format = [:json, :html]
   config.request_headers_to_include = %w(
     Accept
     Content-Type

--- a/spec/fake_app/Gemfile
+++ b/spec/fake_app/Gemfile
@@ -44,7 +44,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem 'apitome'
 
 group :development, :test do
   gem 'rspec'

--- a/spec/fake_app/doc/api.md
+++ b/spec/fake_app/doc/api.md
@@ -1,4 +1,0 @@
-Apitome Documentation
-=====================
-
-This file was automatically generated, and can be found at `doc/api.md`.

--- a/spec/integration/add_to_rails_app_spec.rb
+++ b/spec/integration/add_to_rails_app_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
           run use_local_stitches
           # It's unclear why, but on CI the gems are not found when installed
           # through bundler however installing them explicitly first fixes it.
-          run "gem install apitome rspec-rails rspec_api_documentation"
+          run "gem install rspec-rails rspec_api_documentation"
           run "bundle install"
           example.run
         end
@@ -69,11 +69,9 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
     # It's also in one big block because making a new rails app and running the generator multiple times seems bad.
     aggregate_failures do
       expect(File.exist?(rails_root / "app" / "controllers" / "api" / "api_controller.rb")).to eq(true)
-      expect(rails_root / "Gemfile").to contain_gem("apitome")
       expect(rails_root / "Gemfile").to contain_gem("rspec_api_documentation")
       expect(rails_root / "config" / "routes.rb").to have_route(namespace: :api, module_scope: :v1, resource: 'ping')
       expect(rails_root / "config" / "routes.rb").to have_route(namespace: :api, module_scope: :v2, resource: 'ping')
-      expect(rails_root / "config" / "routes.rb").to have_mounted_engine("Apitome::Engine")
       migrations = Dir["#{rails_root}/db/migrate/*.rb"].sort
       expect(migrations.size).to eq(2)
       expect(migrations[0]).to match(/\/\d+_enable_uuid_ossp_extension.rb/)
@@ -81,8 +79,6 @@ RSpec.describe "Adding Stitches to a New Rails App", :integration do
       expect(File.read(rails_root / "spec" / "rails_helper.rb")).to include("config.include RSpec::Rails::RequestExampleGroup, type: :feature")
       expect(File.read(rails_root / "spec" / "rails_helper.rb")).to include("require 'stitches/spec'")
       expect(File.read(rails_root / "spec" / "rails_helper.rb")).to include("require 'rspec_api_documentation'")
-      expect(File.read(rails_root / "config" / "initializers" / "apitome.rb")).to include("config.mount_at = nil")
-      expect(File.read(rails_root / "config" / "initializers" / "apitome.rb")).to include("config.title = 'Service Documentation'")
       expect(File.read(rails_root / "app" / "controllers" / "api" / "api_controller.rb")).to include("rescue_from StandardError")
       expect(File.read(rails_root / "app" / "controllers" / "api" / "api_controller.rb")).to include("rescue_from ActiveRecord::RecordNotFound")
 


### PR DESCRIPTION
## Problem

apitome is not receiving regular maintenance and has a compatibility issue with Ruby 3. 

## Solution

Remove it. HTML documentation generated with rspec_api_documentation is acceptable.

This change only affects the `stitches:api` Rails generator and will not affect applications already using Stitches.
