### PR TITLE
Update api_spec to not use capyabara

### DIFF
--- a/lib/stitches/api_generator.rb
+++ b/lib/stitches/api_generator.rb
@@ -47,7 +47,7 @@ end
       copy_file "app/models/api_client.rb"
       copy_file "config/initializers/stitches.rb"
       copy_file "lib/tasks/generate_api_key.rake"
-      template "spec/features/api_spec.rb.erb", "spec/features/api_spec.rb"
+      template "spec/requests/api_spec.rb.erb", "spec/requests/api_spec.rb"
       copy_file "spec/acceptance/ping_v1_spec.rb", "spec/acceptance/ping_v1_spec.rb"
 
       migration_template "db/migrate/enable_uuid_ossp_extension.rb", "db/migrate/enable_uuid_ossp_extension.rb"

--- a/lib/stitches/generator_files/spec/requests/api_spec.rb.erb
+++ b/lib/stitches/generator_files/spec/requests/api_spec.rb.erb
@@ -1,6 +1,6 @@
 require 'rails_helper.rb'
 
-feature "general API stuff" do
+RSpec.describe  "general API stuff", type: :request  do
   scenario "good request" do
     headers = TestHeaders.new
 <% if ::Rails::VERSION::MAJOR >= 5 -%>


### PR DESCRIPTION
## Problem

The `api_spec` is a feature test, which means it requires the capybara gem. Most services probably don't need capybara since it's usually for testing front end interactions. We can achieve the same result as the feature test by using a request spec, which means that services won't require capybara off the bat.

## Solution

Update `api_spec` to be a request spec instead of a feature test (also opening a PR in app-template)
