### PR TITLE
these configuration details don't work for newer versions of Rails

### DIFF
--- a/spec/fake_app/config/application.rb
+++ b/spec/fake_app/config/application.rb
@@ -12,7 +12,6 @@ require "action_mailbox/engine"
 require "action_text/engine"
 require "action_view/railtie"
 # require "action_cable/engine"
-require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/spec/fake_app/config/initializers/assets.rb
+++ b/spec/fake_app/config/initializers/assets.rb
@@ -1,8 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
-# Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
-
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 


### PR DESCRIPTION
## Problem

Build is failing. Errors tell me this has to do with changes to the framework in newer versions

## Solution

Remove configuration details causing tests to fail
