### PR TITLE
Remove support for old versions of Rails

### DIFF
--- a/Gemfile.rails-4.2
+++ b/Gemfile.rails-4.2
@@ -1,8 +1,0 @@
-# DO NOT MODIFY - this is managed by Git Reduce in goro
-#
-source 'https://gem.fury.io/me/'
-source 'https://www.rubygems.org'
-
-gemspec
-
-gem 'rails', '~> 4.2.0'

--- a/Gemfile.rails-5.0
+++ b/Gemfile.rails-5.0
@@ -1,8 +1,0 @@
-# DO NOT MODIFY - this is managed by Git Reduce in goro
-#
-source 'https://gem.fury.io/me/'
-source 'https://www.rubygems.org'
-
-gemspec
-
-gem 'rails', '~> 5.0.0'

--- a/Gemfile.rails-5.1
+++ b/Gemfile.rails-5.1
@@ -1,7 +1,0 @@
-# DO NOT MODIFY - this is managed by Git Reduce in goro
-#
-source 'https://stitchfix01.jfrog.io/stitchfix01/api/gems/eng-gems/'
-
-gemspec
-
-gem 'rails', '~> 5.1.0'

--- a/Gemfile.rails-5.2
+++ b/Gemfile.rails-5.2
@@ -1,7 +1,0 @@
-# DO NOT MODIFY - this is managed by Git Reduce in goro
-#
-source 'https://stitchfix01.jfrog.io/stitchfix01/api/gems/eng-gems/'
-
-gemspec
-
-gem 'rails', '~> 5.2.0'

--- a/Gemfile.rails-6.0
+++ b/Gemfile.rails-6.0
@@ -1,7 +1,0 @@
-# DO NOT MODIFY - this is managed by Git Reduce in goro
-#
-source 'https://stitchfix01.jfrog.io/stitchfix01/api/gems/eng-gems/'
-
-gemspec
-
-gem 'rails', '~> 6.0.0'


### PR DESCRIPTION
## Problem

There are some Gemfiles for unsupported versions of Rails.

## Solution

Only keep the latest two versions - 6.1 and 7.0.
