### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 # This file uses the GitHub CODEOWNERS convention to assign PR reviewers:
 # https://help.github.com/articles/about-codeowners/
 
-* @stitchfix/app-platform @brettfishman
+* @stitchfix/app-platform


### PR DESCRIPTION
Remove myself from CODEOWNERS file.

## Problem

I receive GH notifications whenever a PR is opened in this repo because I am listed in `CODEOWNERS`.

## Solution

Remove myself from `CODEOWNERS`, and let the amazing App Platform team take it from here. 🙌 
