### PR TITLE
Configuration to disable api key support

### DIFF
--- a/lib/stitches/api_key.rb
+++ b/lib/stitches/api_key.rb
@@ -23,6 +23,8 @@ module Stitches
   protected
 
     def do_call(env)
+      return @app.call(env) if Stitches.configuration.disable_api_key_support
+
       authorization = env["HTTP_AUTHORIZATION"]
       if authorization
         if authorization =~ /#{configuration.custom_http_auth_scheme}\s+key=(.*)\s*$/

--- a/lib/stitches/configuration.rb
+++ b/lib/stitches/configuration.rb
@@ -17,9 +17,10 @@ class Stitches::Configuration
     @max_cache_size = NonNullInteger.new("max_cache_size", 0)
     @disabled_key_leniency_in_seconds = ActiveSupport::Duration.days(3)
     @disabled_key_leniency_error_log_threshold_in_seconds = ActiveSupport::Duration.days(2)
+    @disable_api_key_support = false
   end
 
-  attr_accessor :disabled_key_leniency_in_seconds, :disabled_key_leniency_error_log_threshold_in_seconds
+  attr_accessor :disabled_key_leniency_in_seconds, :disabled_key_leniency_error_log_threshold_in_seconds, :disable_api_key_support
 
   # A RegExp that allows URLS around the mime type and api key requirements.
   # nil means that ever request must have a proper mime type and api key.

--- a/spec/api_key_middleware_spec.rb
+++ b/spec/api_key_middleware_spec.rb
@@ -12,13 +12,6 @@ RSpec.describe "/api/hellos", type: :request do
   let(:auth_header) { "MyAwesomeInternalScheme key=#{uuid}" }
   let(:allowlist) { nil }
 
-  before do
-    Stitches.configuration.reset_to_defaults!
-    Stitches.configuration.custom_http_auth_scheme = 'MyAwesomeInternalScheme'
-    Stitches.configuration.allowlist_regexp = allowlist if allowlist
-    Stitches::ApiClientAccessWrapper.clear_api_cache
-  end
-
   def execute_call(auth: auth_header)
     headers = {
       "Accept" => "application/json; version=1"
@@ -34,16 +27,368 @@ RSpec.describe "/api/hellos", type: :request do
     expect(response.headers["WWW-Authenticate"]).to eq("MyAwesomeInternalScheme realm=FakeApp")
   end
 
-  context "with modern schema" do
-    let(:api_client_enabled) { true }
-    let(:disabled_at) { nil }
-    let!(:api_client) {
-      uuid = SecureRandom.uuid
-      ApiClient.create(name: "MyApiClient", key: SecureRandom.uuid, enabled: false, created_at: 20.days.ago, disabled_at: 15.days.ago)
-      ApiClient.create(name: "MyApiClient", key: uuid, enabled: api_client_enabled, created_at: 10.days.ago, disabled_at: disabled_at)
-    }
+  context "disabled api key support" do
+    before do
+      Stitches.configuration.reset_to_defaults!
+      Stitches.configuration.custom_http_auth_scheme = 'MyAwesomeInternalScheme'
+      Stitches.configuration.disable_api_key_support = true
+    end
 
-    context "when path is not on allowlist" do
+    let(:uuid) { SecureRandom.uuid }
+
+    it "executes the correct controller" do
+      execute_call
+
+      expect(response.body).to include "Hello"
+    end
+
+    it "does not look up information from the database" do
+      execute_call
+
+      expect(response.body).to include "NameNotFound"
+      expect(response.body).to include "IdNotFound"
+    end
+
+    it "indicates a successful response" do
+      execute_call
+
+      expect(response.status).to eq 200
+    end
+  end
+
+  context "enabled api key support" do
+    before do
+      Stitches.configuration.reset_to_defaults!
+      Stitches.configuration.custom_http_auth_scheme = 'MyAwesomeInternalScheme'
+      Stitches.configuration.allowlist_regexp = allowlist if allowlist
+      Stitches.configuration.disable_api_key_support = false
+      Stitches::ApiClientAccessWrapper.clear_api_cache
+    end
+
+    context "with modern schema" do
+      let(:api_client_enabled) { true }
+      let(:disabled_at) { nil }
+      let!(:api_client) {
+        uuid = SecureRandom.uuid
+        ApiClient.create(name: "MyApiClient", key: SecureRandom.uuid, enabled: false, created_at: 20.days.ago, disabled_at: 15.days.ago)
+        ApiClient.create(name: "MyApiClient", key: uuid, enabled: api_client_enabled, created_at: 10.days.ago, disabled_at: disabled_at)
+      }
+
+      context "when path is not on allowlist" do
+        context "when api_client is valid" do
+          it "executes the correct controller" do
+            execute_call
+
+            expect(response.body).to include "Hello"
+          end
+
+          it "saves the api_client information used" do
+            execute_call
+
+            expect(response.body).to include "MyApiClient"
+            expect(response.body).to include "#{api_client.id}"
+          end
+
+          context "caching is enabled" do
+            before do
+              allow(ApiClient).to receive(:find_by).and_call_original
+
+              Stitches.configure do |config|
+                config.max_cache_ttl  = 5
+                config.max_cache_size = 10
+              end
+            end
+
+            it "only gets the the api_client information once" do
+              execute_call
+              execute_call
+
+              expect(response.body).to include "#{api_client.id}"
+              expect(ApiClient).to have_received(:find_by).once
+            end
+          end
+        end
+
+        context "when api client key does not match" do
+          let(:uuid) { SecureRandom.uuid } # random uuid
+
+          it "rejects request" do
+            execute_call
+
+            expect_unauthorized
+          end
+        end
+
+        context "when api client key not enabled" do
+          let(:api_client_enabled) { false }
+
+          context "when disabled_at is not set" do
+            it "rejects request" do
+              execute_call
+
+              expect_unauthorized
+            end
+          end
+
+          context "when disabled_at is set to a time older than three days ago" do
+            let(:disabled_at) { 4.day.ago }
+
+            it "does not allow the call" do
+              execute_call
+
+              expect_unauthorized
+
+            end
+          end
+
+          context "when disabled_at is set to a recent time" do
+            let(:disabled_at) { 1.day.ago }
+
+            it "allows the call" do
+              execute_call
+
+              expect(response.body).to include "Hello"
+              expect(response.body).to include "MyApiClient"
+              expect(response.body).to include "#{api_client.id}"
+            end
+
+            it "warns about the disabled key to log writer when available" do
+              stub_const("StitchFix::Logger::LogWriter", FakeLogger.new)
+              allow(StitchFix::Logger::LogWriter).to receive(:warn)
+
+              execute_call
+
+              expect(StitchFix::Logger::LogWriter).to have_received(:warn).once
+            end
+
+            it "warns about the disabled key to the Rails.logger" do
+              allow(Rails.logger).to receive(:warn)
+              allow(Rails.logger).to receive(:error)
+
+              execute_call
+
+              expect(Rails.logger).to have_received(:warn).once
+              expect(Rails.logger).not_to have_received(:error)
+            end
+          end
+
+          context "when disabled_at is set to a dangerously long time" do
+            let(:disabled_at) { 52.hours.ago }
+
+            it "allows the call" do
+              execute_call
+
+              expect(response.body).to include "Hello"
+              expect(response.body).to include "MyApiClient"
+              expect(response.body).to include "#{api_client.id}"
+            end
+
+            it "logs error about the disabled key to log writer when available" do
+              stub_const("StitchFix::Logger::LogWriter", FakeLogger.new)
+              allow(StitchFix::Logger::LogWriter).to receive(:error)
+
+              execute_call
+
+              expect(StitchFix::Logger::LogWriter).to have_received(:error).once
+            end
+
+            it "logs error about the disabled key to the Rails.logger" do
+              allow(Rails.logger).to receive(:warn)
+              allow(Rails.logger).to receive(:error) do |message1|
+                expect(message1).not_to include uuid
+              end
+
+              execute_call
+
+              expect(Rails.logger).to have_received(:error).once
+              expect(Rails.logger).not_to have_received(:warn)
+            end
+          end
+
+          context "when disabled_at is set to an unacceptably long time" do
+            let(:disabled_at) { 5.days.ago }
+
+            it "forbids the call" do
+              execute_call
+
+              expect_unauthorized
+            end
+
+            it "logs error about the disabled key to log writer when available" do
+              stub_const("StitchFix::Logger::LogWriter", FakeLogger.new)
+              allow(StitchFix::Logger::LogWriter).to receive(:error)
+
+              execute_call
+
+              expect(StitchFix::Logger::LogWriter).to have_received(:error).once
+            end
+
+            it "logs error about the disabled key to the Rails.logger" do
+              allow(Rails.logger).to receive(:warn)
+              allow(Rails.logger).to receive(:error)
+
+              execute_call
+
+              expect(Rails.logger).to have_received(:error).once
+              expect(Rails.logger).not_to have_received(:warn)
+            end
+          end
+
+          context "custom leniency is set" do
+            before do
+              Stitches.configuration.disabled_key_leniency_in_seconds = 100
+              Stitches.configuration.disabled_key_leniency_error_log_threshold_in_seconds = 50
+            end
+
+            context "when disabled_at is set to an unacceptably long time" do
+              let(:disabled_at) { 101.seconds.ago }
+
+              it "forbids the call" do
+                allow(Rails.logger).to receive(:error) do |message1|
+                  expect(message1).not_to include uuid
+                end
+
+                execute_call
+
+                expect_unauthorized
+                expect(Rails.logger).to have_received(:error).once
+              end
+            end
+
+            context "when disabled_at is set to a dangerously long time" do
+              let(:disabled_at) { 75.seconds.ago }
+
+              it "allows the call" do
+                allow(Rails.logger).to receive(:error)
+
+                execute_call
+
+                expect(response.body).to include "Hello"
+                expect(Rails.logger).to have_received(:error).once
+              end
+            end
+
+            context "when disabled_at is set to a short time ago" do
+              let(:disabled_at) { 25.seconds.ago }
+
+              it "allows the call" do
+                allow(Rails.logger).to receive(:warn) do |message1|
+                  expect(message1).not_to include uuid
+                end
+
+                execute_call
+
+                expect(response.body).to include "Hello"
+                expect(Rails.logger).to have_received(:warn).once
+              end
+            end
+          end
+        end
+
+        context "when authorization header is missing" do
+          it "rejects request" do
+            execute_call(auth: nil)
+
+            expect_unauthorized
+          end
+        end
+
+        context "when scheme does not match" do
+          it "rejects request" do
+            execute_call(auth: "OtherScheme key=#{uuid}")
+
+            expect_unauthorized
+          end
+        end
+      end
+
+      context "when path is on allowlist" do
+        let(:allowlist) { /.*hello.*/ }
+
+        context "when api_client is valid" do
+          it "executes the correct controller" do
+            execute_call
+
+            expect(response.body).to include "Hello"
+          end
+
+          it "does not save the api_client information used" do
+            execute_call
+
+            expect(response.body).to include "NameNotFound"
+            expect(response.body).to include "IdNotFound"
+          end
+        end
+
+        context "when api client key does not match" do
+          let(:uuid) { SecureRandom.uuid } # random uuid
+
+          it "executes the correct controller" do
+            execute_call
+
+            expect(response.body).to include "Hello"
+          end
+        end
+      end
+    end
+
+    context "when schema is old and missing disabled_at field" do
+      around(:each) do |example|
+        load 'fake_app/db/schema_missing_disabled_at.rb'
+        ApiClient.reset_column_information
+        example.run
+        load 'fake_app/db/schema_modern.rb'
+        ApiClient.reset_column_information
+      end
+
+      context "when api_client is valid" do
+        let!(:api_client) {
+          uuid = SecureRandom.uuid
+          ApiClient.create(name: "MyApiClient", key: uuid, created_at: Time.now(), enabled: true)
+        }
+
+        it "executes the correct controller" do
+          execute_call
+
+          expect(response.body).to include "Hello"
+        end
+
+        it "saves the api_client information used" do
+          execute_call
+
+          expect(response.body).to include "MyApiClient"
+          expect(response.body).to include "#{api_client.id}"
+        end
+      end
+
+      context "when api_client is not enabled" do
+        let!(:api_client) {
+          uuid = SecureRandom.uuid
+          ApiClient.create(name: "MyApiClient", key: uuid, created_at: Time.now(), enabled: false)
+        }
+
+        it "rejects request" do
+          execute_call
+
+          expect_unauthorized
+        end
+      end
+    end
+
+    context "when schema is old and missing enabled field" do
+      around(:each) do |example|
+        load 'fake_app/db/schema_missing_enabled.rb'
+        ApiClient.reset_column_information
+        example.run
+        load 'fake_app/db/schema_modern.rb'
+        ApiClient.reset_column_information
+      end
+
+      let!(:api_client) {
+        uuid = SecureRandom.uuid
+        ApiClient.create(name: "MyApiClient", key: uuid, created_at: Time.now())
+      }
+
       context "when api_client is valid" do
         it "executes the correct controller" do
           execute_call
@@ -57,319 +402,6 @@ RSpec.describe "/api/hellos", type: :request do
           expect(response.body).to include "MyApiClient"
           expect(response.body).to include "#{api_client.id}"
         end
-
-        context "caching is enabled" do
-          before do
-            allow(ApiClient).to receive(:find_by).and_call_original
-
-            Stitches.configure do |config|
-              config.max_cache_ttl  = 5
-              config.max_cache_size = 10
-            end
-          end
-
-          it "only gets the the api_client information once" do
-            execute_call
-            execute_call
-
-            expect(response.body).to include "#{api_client.id}"
-            expect(ApiClient).to have_received(:find_by).once
-          end
-        end
-      end
-
-      context "when api client key does not match" do
-        let(:uuid) { SecureRandom.uuid } # random uuid
-
-        it "rejects request" do
-          execute_call
-
-          expect_unauthorized
-        end
-      end
-
-      context "when api client key not enabled" do
-        let(:api_client_enabled) { false }
-
-        context "when disabled_at is not set" do
-          it "rejects request" do
-            execute_call
-
-            expect_unauthorized
-          end
-        end
-
-        context "when disabled_at is set to a time older than three days ago" do
-          let(:disabled_at) { 4.day.ago }
-
-          it "does not allow the call" do
-            execute_call
-
-            expect_unauthorized
-
-          end
-        end
-
-        context "when disabled_at is set to a recent time" do
-          let(:disabled_at) { 1.day.ago }
-
-          it "allows the call" do
-            execute_call
-
-            expect(response.body).to include "Hello"
-            expect(response.body).to include "MyApiClient"
-            expect(response.body).to include "#{api_client.id}"
-          end
-
-          it "warns about the disabled key to log writer when available" do
-            stub_const("StitchFix::Logger::LogWriter", FakeLogger.new)
-            allow(StitchFix::Logger::LogWriter).to receive(:warn)
-
-            execute_call
-
-            expect(StitchFix::Logger::LogWriter).to have_received(:warn).once
-          end
-
-          it "warns about the disabled key to the Rails.logger" do
-            allow(Rails.logger).to receive(:warn)
-            allow(Rails.logger).to receive(:error)
-
-            execute_call
-
-            expect(Rails.logger).to have_received(:warn).once
-            expect(Rails.logger).not_to have_received(:error)
-          end
-        end
-
-        context "when disabled_at is set to a dangerously long time" do
-          let(:disabled_at) { 52.hours.ago }
-
-          it "allows the call" do
-            execute_call
-
-            expect(response.body).to include "Hello"
-            expect(response.body).to include "MyApiClient"
-            expect(response.body).to include "#{api_client.id}"
-          end
-
-          it "logs error about the disabled key to log writer when available" do
-            stub_const("StitchFix::Logger::LogWriter", FakeLogger.new)
-            allow(StitchFix::Logger::LogWriter).to receive(:error)
-
-            execute_call
-
-            expect(StitchFix::Logger::LogWriter).to have_received(:error).once
-          end
-
-          it "logs error about the disabled key to the Rails.logger" do
-            allow(Rails.logger).to receive(:warn)
-            allow(Rails.logger).to receive(:error) do |message1|
-              expect(message1).not_to include uuid
-            end
-
-            execute_call
-
-            expect(Rails.logger).to have_received(:error).once
-            expect(Rails.logger).not_to have_received(:warn)
-          end
-        end
-
-        context "when disabled_at is set to an unacceptably long time" do
-          let(:disabled_at) { 5.days.ago }
-
-          it "forbids the call" do
-            execute_call
-
-            expect_unauthorized
-          end
-
-          it "logs error about the disabled key to log writer when available" do
-            stub_const("StitchFix::Logger::LogWriter", FakeLogger.new)
-            allow(StitchFix::Logger::LogWriter).to receive(:error)
-
-            execute_call
-
-            expect(StitchFix::Logger::LogWriter).to have_received(:error).once
-          end
-
-          it "logs error about the disabled key to the Rails.logger" do
-            allow(Rails.logger).to receive(:warn)
-            allow(Rails.logger).to receive(:error)
-
-            execute_call
-
-            expect(Rails.logger).to have_received(:error).once
-            expect(Rails.logger).not_to have_received(:warn)
-          end
-        end
-
-        context "custom leniency is set" do
-          before do
-            Stitches.configuration.disabled_key_leniency_in_seconds = 100
-            Stitches.configuration.disabled_key_leniency_error_log_threshold_in_seconds = 50
-          end
-
-          context "when disabled_at is set to an unacceptably long time" do
-            let(:disabled_at) { 101.seconds.ago }
-
-            it "forbids the call" do
-              allow(Rails.logger).to receive(:error) do |message1|
-                expect(message1).not_to include uuid
-              end
-
-              execute_call
-
-              expect_unauthorized
-              expect(Rails.logger).to have_received(:error).once
-            end
-          end
-
-          context "when disabled_at is set to a dangerously long time" do
-            let(:disabled_at) { 75.seconds.ago }
-
-            it "allows the call" do
-              allow(Rails.logger).to receive(:error)
-
-              execute_call
-
-              expect(response.body).to include "Hello"
-              expect(Rails.logger).to have_received(:error).once
-            end
-          end
-
-          context "when disabled_at is set to a short time ago" do
-            let(:disabled_at) { 25.seconds.ago }
-
-            it "allows the call" do
-              allow(Rails.logger).to receive(:warn) do |message1|
-                expect(message1).not_to include uuid
-              end
-
-              execute_call
-
-              expect(response.body).to include "Hello"
-              expect(Rails.logger).to have_received(:warn).once
-            end
-          end
-        end
-      end
-
-      context "when authorization header is missing" do
-        it "rejects request" do
-          execute_call(auth: nil)
-
-          expect_unauthorized
-        end
-      end
-
-      context "when scheme does not match" do
-        it "rejects request" do
-          execute_call(auth: "OtherScheme key=#{uuid}")
-
-          expect_unauthorized
-        end
-      end
-    end
-
-    context "when path is on allowlist" do
-      let(:allowlist) { /.*hello.*/ }
-
-      context "when api_client is valid" do
-        it "executes the correct controller" do
-          execute_call
-
-          expect(response.body).to include "Hello"
-        end
-
-        it "does not save the api_client information used" do
-          execute_call
-
-          expect(response.body).to include "NameNotFound"
-          expect(response.body).to include "IdNotFound"
-        end
-      end
-
-      context "when api client key does not match" do
-        let(:uuid) { SecureRandom.uuid } # random uuid
-
-        it "executes the correct controller" do
-          execute_call
-
-          expect(response.body).to include "Hello"
-        end
-      end
-    end
-  end
-
-  context "when schema is old and missing disabled_at field" do
-    around(:each) do |example|
-      load 'fake_app/db/schema_missing_disabled_at.rb'
-      ApiClient.reset_column_information
-      example.run
-      load 'fake_app/db/schema_modern.rb'
-      ApiClient.reset_column_information
-    end
-
-    context "when api_client is valid" do
-      let!(:api_client) {
-        uuid = SecureRandom.uuid
-        ApiClient.create(name: "MyApiClient", key: uuid, created_at: Time.now(), enabled: true)
-      }
-
-      it "executes the correct controller" do
-        execute_call
-
-        expect(response.body).to include "Hello"
-      end
-
-      it "saves the api_client information used" do
-        execute_call
-
-        expect(response.body).to include "MyApiClient"
-        expect(response.body).to include "#{api_client.id}"
-      end
-    end
-
-    context "when api_client is not enabled" do
-      let!(:api_client) {
-        uuid = SecureRandom.uuid
-        ApiClient.create(name: "MyApiClient", key: uuid, created_at: Time.now(), enabled: false)
-      }
-
-      it "rejects request" do
-        execute_call
-
-        expect_unauthorized
-      end
-    end
-  end
-
-  context "when schema is old and missing enabled field" do
-    around(:each) do |example|
-      load 'fake_app/db/schema_missing_enabled.rb'
-      ApiClient.reset_column_information
-      example.run
-      load 'fake_app/db/schema_modern.rb'
-      ApiClient.reset_column_information
-    end
-
-    let!(:api_client) {
-      uuid = SecureRandom.uuid
-      ApiClient.create(name: "MyApiClient", key: uuid, created_at: Time.now())
-    }
-
-    context "when api_client is valid" do
-      it "executes the correct controller" do
-        execute_call
-
-        expect(response.body).to include "Hello"
-      end
-
-      it "saves the api_client information used" do
-        execute_call
-
-        expect(response.body).to include "MyApiClient"
-        expect(response.body).to include "#{api_client.id}"
       end
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -44,6 +44,10 @@ describe Stitches::Configuration do
       expect(Stitches.configuration.max_cache_size).to eq(0)
     end
 
+    it "sets a default of false for disable_api_key_support" do
+      expect(Stitches.configuration.disable_api_key_support).to be false
+    end
+
     it "blows up if you try to use custom_http_auth_scheme without having set it" do
       expect {
         Stitches.configuration.custom_http_auth_scheme


### PR DESCRIPTION
## Problem

Using API keys for auth should be optional. A user should still be able to benefit from other features in the library.

## Solution

```ruby
Stitches.configure do |config|
  config.disable_api_key_support = true
end
```