### PR TITLE
Update CODEOWNERS to @stitchfix/platform-insights-and-reliability-engineering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
             fi
       - run:
           name: Notify Pager Duty
-          command: bundle exec y-notify "#app-platform-ops"
+          command: bundle exec y-notify "#pire-ops"
           when: on_fail
       - store_test_results:
           path: "/tmp/test-results"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 # This file uses the GitHub CODEOWNERS convention to assign PR reviewers:
 # https://help.github.com/articles/about-codeowners/
 
-* @stitchfix/app-platform
+* @stitchfix/platform-insights-and-reliability-engineering


### PR DESCRIPTION
This PR updates CODEOWNERS entries from `@stitchfix/app-platform` to `@stitchfix/platform-insights-and-reliability-engineering`.