### PR TITLE
disable api key auth by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Then, set it up:
 > bundle exec rake db:migrate               # only if you're using API key authentication
 ```
 
-### Disable API Key Support
+### Enable API Key Support
 
-If you're not using the API Key authentication feature of the library, configure stitches:
+API key authentication is disabled by default. To enable it:
 
 ```ruby
 Stitches.configure do |config|
-  config.disable_api_key_support = true
+  config.disable_api_key_support = false
 end
 ```
 

--- a/lib/stitches/configuration.rb
+++ b/lib/stitches/configuration.rb
@@ -17,7 +17,7 @@ class Stitches::Configuration
     @max_cache_size = NonNullInteger.new("max_cache_size", 0)
     @disabled_key_leniency_in_seconds = ActiveSupport::Duration.days(3)
     @disabled_key_leniency_error_log_threshold_in_seconds = ActiveSupport::Duration.days(2)
-    @disable_api_key_support = false
+    @disable_api_key_support = true
   end
 
   attr_accessor :disabled_key_leniency_in_seconds, :disabled_key_leniency_error_log_threshold_in_seconds, :disable_api_key_support

--- a/lib/stitches/version.rb
+++ b/lib/stitches/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stitches
-  VERSION = '5.0.0'
+  VERSION = '6.0.0.RC1'
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -44,8 +44,8 @@ describe Stitches::Configuration do
       expect(Stitches.configuration.max_cache_size).to eq(0)
     end
 
-    it "sets a default of false for disable_api_key_support" do
-      expect(Stitches.configuration.disable_api_key_support).to be false
+    it "sets a default of true for disable_api_key_support" do
+      expect(Stitches.configuration.disable_api_key_support).to be true
     end
 
     it "blows up if you try to use custom_http_auth_scheme without having set it" do


### PR DESCRIPTION
https://stitchfix.atlassian.net/browse/DP-4629

## Problem

#123 made api key auth support a toggle, but it's still enabled by default. Now that we want to disable it widely, to avoid config changes across many apps, we should update the default configuration to **disabled**.

## Solution

Make `disable_api_key_support = true` the default. The resulting naming for **enabling** is unfortunate (double-negative), but that should be a rare case.

A future release could remove api key support altogether if desired.
