### PR TITLE
CallingServiceMiddleware: fallback api_client when no header present

### DIFF
--- a/lib/stitches/calling_service_middleware.rb
+++ b/lib/stitches/calling_service_middleware.rb
@@ -17,9 +17,8 @@ module Stitches
         header_name = Stitches.configuration.calling_service_header
         rack_key = "HTTP_#{header_name.upcase.tr('-', '_')}"
 
-        if (name = env[rack_key]).present?
-          env[client_key] = CallingServiceClient.new(name)
-        end
+        name = env[rack_key].presence || ""
+        env[client_key] = CallingServiceClient.new(name)
       end
 
       @app.call(env)

--- a/lib/stitches/version.rb
+++ b/lib/stitches/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stitches
-  VERSION = '5.1.0'
+  VERSION = '5.1.1'
 end

--- a/spec/api_key_middleware_spec.rb
+++ b/spec/api_key_middleware_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "/api/hellos", type: :request do
     it "does not look up information from the database" do
       execute_call
 
-      expect(response.body).to include "NameNotFound"
+      expect(response.body).to include "Hello ,"
       expect(response.body).to include "IdNotFound"
     end
 
@@ -315,7 +315,7 @@ RSpec.describe "/api/hellos", type: :request do
           it "does not save the api_client information used" do
             execute_call
 
-            expect(response.body).to include "NameNotFound"
+            expect(response.body).to include "Hello ,"
             expect(response.body).to include "IdNotFound"
           end
         end

--- a/spec/calling_service_middleware_spec.rb
+++ b/spec/calling_service_middleware_spec.rb
@@ -37,18 +37,24 @@ describe Stitches::CallingServiceMiddleware do
     end
 
     context "when the header is absent and env var is not set" do
-      it "leaves the env var nil" do
+      it "sets a fallback CallingServiceClient with empty name" do
         _status, result_env, _body = middleware.call(env)
-        expect(result_env[client_key]).to be_nil
+        client = result_env[client_key]
+
+        expect(client).to be_a(Stitches::CallingServiceClient)
+        expect(client.name).to eq("")
       end
     end
 
     context "when the header is blank" do
       before { env["HTTP_X_STITCHFIX_CALLING_SERVICE"] = "" }
 
-      it "leaves the env var nil" do
+      it "sets a fallback CallingServiceClient with empty name" do
         _status, result_env, _body = middleware.call(env)
-        expect(result_env[client_key]).to be_nil
+        client = result_env[client_key]
+
+        expect(client).to be_a(Stitches::CallingServiceClient)
+        expect(client.name).to eq("")
       end
     end
 


### PR DESCRIPTION
https://stitchfix.atlassian.net/browse/DP-4850

## PROBLEM

When `disable_api_key_support = true` and a request arrives without the `X-StitchFix-Calling-Service` header (old clients, health checks, curl), `api_client` is nil. Apps that call `api_client.name` unconditionally (e.g. in `before_action` for metrics tagging) crash with `NoMethodError`.

We found 31 uses of `api_client.name` across 17 apps. Requiring each to add safe navigation defeats the "no code changes needed" promise.

## SOLUTION

`CallingServiceMiddleware` now always populates the caller identity env var with a `CallingServiceClient` struct when no other auth middleware has set it:

- Header present → `CallingServiceClient.new("the-service-name")`
- Header absent → `CallingServiceClient.new("")`

This means `api_client.name` never raises — it returns the calling service name when the header is sent, or empty string when it's not. No magic strings, no crashes, consistent with `calling_service_name` returning `""` for absent headers.

**Resolution order (unchanged):**
1. ApiKey middleware authenticated → real `ApiClient` record (wins)
2. JWT/other auth set the env var → that object (wins)
3. Header present, nothing else set → `CallingServiceClient` with name from header
4. Nothing at all → `CallingServiceClient` with empty name

Verified with `kept-items-service` acceptance specs — all pass with the local stitches source.

## Test plan

- [x] `calling_service_middleware_spec` passes (header present, absent, blank, custom config, pre-existing env var)
- [x] `calling_service_name_spec` passes
- [x] `kept-items-service` acceptance specs pass with local stitches